### PR TITLE
fix: convert timeout from seconds to milliseconds for SDK (#12)

### DIFF
--- a/src/adapter/sdk-copilot.ts
+++ b/src/adapter/sdk-copilot.ts
@@ -113,7 +113,10 @@ export class SdkCopilotAdapter implements IAgentAdapter {
         }
       });
 
-      await session.sendAndWait({ prompt: prompt.trim() }, options.timeout ? options.timeout * 1000 : undefined);
+      await session.sendAndWait(
+        { prompt: prompt.trim() },
+        options.timeout ? options.timeout * 1000 : undefined,
+      );
 
       return {
         output,

--- a/src/adapter/sdk-copilot.ts
+++ b/src/adapter/sdk-copilot.ts
@@ -113,7 +113,7 @@ export class SdkCopilotAdapter implements IAgentAdapter {
         }
       });
 
-      await session.sendAndWait({ prompt: prompt.trim() }, options.timeout);
+      await session.sendAndWait({ prompt: prompt.trim() }, options.timeout ? options.timeout * 1000 : undefined);
 
       return {
         output,


### PR DESCRIPTION
## Bug

`sendAndWait()` expects milliseconds but minih passed seconds from frontmatter/CLI. `1800s` became `1800ms = 1.8s` → instant timeout, agents die after first turn with zero tool calls.

## Fix

```typescript
// Before
await session.sendAndWait({ prompt }, options.timeout);

// After  
await session.sendAndWait({ prompt }, options.timeout ? options.timeout * 1000 : undefined);
```

## Evidence

- Reporter verified root cause by reading SDK source (`session.js:117`)
- Reproduction script confirmed: 1800ms timeout = immediate death, 1800000ms = works

Closes #12