### PR TITLE
test(runner): loosen the last CI-flaky timing test (the (c) cleanup test)

### DIFF
--- a/test/runner/companion-longevity.test.ts
+++ b/test/runner/companion-longevity.test.ts
@@ -197,12 +197,14 @@ describe('survive-gaps heartbeat factory (plan 028 T001/T002)', () => {
     const stop = startManifestHeartbeat(runDir, 15);
     await delay(50);
     stop();
-    // Let any write scheduled by the last pre-stop tick settle (updateManifest
-    // is async + per-runDir serialized), then snapshot the stable value.
-    await delay(40);
+    // Generously let any write scheduled by the last pre-stop tick settle
+    // (updateManifest is async + per-runDir serialized) before snapshotting —
+    // slow/loaded CI can delay that write well past a few ms, so this margin is
+    // wide on purpose.
+    await delay(250);
     const frozen = updatedAtMs(runDir);
 
-    await delay(70); // would tick ~4 more times if the interval leaked
+    await delay(150); // a leaked 15ms interval would tick ~10x in this window
     expect(updatedAtMs(runDir)).toBe(frozen);
   });
 });


### PR DESCRIPTION
## What

Loosen the timing margins on the `(c) stop() clears the timer` test in `test/runner/companion-longevity.test.ts` — the last CI-flaky real-timer test from plan 028.

## Why

It snapshotted the "frozen" `updatedAt` only **40ms** after `stop()`. On a slow/loaded CI runner, the last pre-stop heartbeat write (fire-and-forget, async) landed **~87ms** later and bumped `updatedAt` after the snapshot, tripping the no-further-writes assertion. This went red on the **v0.2.2 release commit** (`2fbd457`) — on code identical to the green feature merge (`c8dfcf7`), so it's pure timing fragility, not a regression. (A re-run greened main, but the test stays fragile for future PRs.)

## Fix

- Post-stop settle: **40ms → 250ms** (wide margin for slow CI to flush the in-flight write).
- Leak-detection window: **70ms → 150ms** (a leaked 15ms interval still ticks ~10×).

This is the same loosening already applied to its two siblings (the "advances updatedAt" and "(a) default-run-no-heartbeat" tests) in #52. **Test-only — no source change.** Verified locally: 4× green in a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
