### PR TITLE
feat(telemetry): trace the inter-agent coordination channel (MCP + forwarders) end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ scratch/
 
 # Engineering-harness transient scratch (defense-in-depth above the CLI's self-healed nested .gitignore)
 .harness/temp/
+
+# Local planning/research scratch for in-progress work (not committed)
+temp/

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -71,6 +71,11 @@ Inbox messages carry the producer's `traceparent` (W3C). When the forwarder deli
 message to the inside agent, it creates a `minih.coordination.message_received` span **linked** to
 the producer's span — async messaging connects sender↔receiver with span links, not parent/child.
 
+Coordination spans carry message metadata as attributes: `message.id`, `message.type`,
+`message.sender`, `message.subject`, and `message.body.length`. The full `message.body` is added
+only when `MINIH_TELEMETRY_VERBOSE=true` (DD3 — privacy-safe by default). The same applies to the
+inside agent's `minih.mcp.inbox_send` spans.
+
 Other commands only get telemetry lifecycle (init + flush for logs) but no spans.
 
 ### Metrics

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -27,6 +27,7 @@ open http://localhost:3060
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP collector endpoint. The bundled `just lgtm-up` stack listens on `http://localhost:4328` (remapped to coexist with other stacks); `just telemetry-run` sets this for you. |
 | `OTEL_SERVICE_NAME` | `minih` | Override the service name in traces |
 | `OTEL_RESOURCE_ATTRIBUTES` | — | Additional resource attributes (e.g., `deployment.environment=ci`) |
+| `MINIH_TELEMETRY_FLUSH_MS` | `1500` | Settle window (ms) after a run so the Copilot CLI subprocess flushes its span exporter before shutdown. Bounded to `[0, 30000]`; `0` disables the wait. |
 
 ## What is instrumented
 
@@ -51,6 +52,25 @@ minih.cli.command                              (minih)
 
 SDK spans from `github-copilot` are automatically stitched into the same trace via `onGetTraceContext` (DD13). Two services appear in one trace — this is standard distributed tracing.
 
+#### Coordinated runs
+
+Coordinated agents (those with `coordination: enabled`) add spans for the inter-agent channel.
+The **inside MCP coordination server** runs as a separate process; its tool calls are stitched
+into the run trace via a `TRACEPARENT` injected at spawn (it roots under `minih.run.execution`):
+
+```
+minih.run.execution                            (minih)
+  └── minih.mcp.inbox_send                     (minih · MCP subprocess)
+  └── minih.mcp.state_transition               (minih · MCP subprocess)  [state.from, state.to]
+  └── minih.coordination.message_received      (minih · inbox forwarder)
+        ⇢ link → producer span (from the message's traceparent)
+  └── minih.coordination.state_change          (minih · state forwarder)
+```
+
+Inbox messages carry the producer's `traceparent` (W3C). When the forwarder delivers an outside
+message to the inside agent, it creates a `minih.coordination.message_received` span **linked** to
+the producer's span — async messaging connects sender↔receiver with span links, not parent/child.
+
 Other commands only get telemetry lifecycle (init + flush for logs) but no spans.
 
 ### Metrics
@@ -64,6 +84,9 @@ Other commands only get telemetry lifecycle (init + flush for logs) but no spans
 | `minih.validation.count` | Counter | Validation attempts by result |
 | `minih.prompt.tokens` | Histogram | Prompt token count (GPT tokenizer) |
 | `minih.adapter.session_duration` | Histogram | SDK session duration (ms) |
+| `minih.coordination.messages_sent` | Counter | Inbox messages sent (attrs: `type`, `sender`) |
+| `minih.coordination.messages_received` | Counter | Inbox messages delivered to the inside agent (attr: `type`) |
+| `minih.coordination.state_transitions` | Counter | Inside-state transitions (attrs: `from`, `to`) |
 
 ### Logs
 
@@ -119,6 +142,27 @@ Set `MINIH_TELEMETRY_VERBOSE=true` to include prompt bodies and tool outputs —
 ## Cross-process trace stitching
 
 If minih detects `TRACEPARENT` and `TRACESTATE` environment variables, it uses them as the parent context. This allows stitching traces across process boundaries (e.g., when an agent runs `minih check` during a `minih run`).
+
+### Cross-run stitching (orchestrator → agent)
+
+minih reads `TRACEPARENT` at startup but never sets it for you — so an orchestrator that shells out
+to `minih run` can stitch the child's entire trace under its own span by exporting the active
+context first:
+
+```bash
+# Inside an already-traced process (TRACEPARENT reflects the active span):
+TRACEPARENT="00-<trace>-<span>-01" \
+  MINIH_TELEMETRY=true OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT \
+  minih run worker-agent
+```
+
+The child run's root span (`minih.cli.command`) becomes a child of the supplied context (DD11), so
+the orchestrator and worker appear in one trace.
+
+For **inter-agent messages** (one run writing to another's inbox via `minih outside inbox send`),
+linking is automatic and finer-grained: each message carries the sender's `traceparent`, and the
+receiving run's forwarder emits a `minih.coordination.message_received` span **linked** to the
+sender's span — no env wiring required.
 
 ## Troubleshooting
 

--- a/src/cli/commands/outside.ts
+++ b/src/cli/commands/outside.ts
@@ -39,7 +39,7 @@ import {
 } from '../../runner/index.js';
 import {
   coordinationMessagesSent,
-  getTraceparent,
+  getTraceContext,
 } from '../../telemetry/index.js';
 import {
   appendInboxMessage,
@@ -612,8 +612,9 @@ export function buildOutsideMessage(input: OutsideMessageInput): InboxMessage {
   };
   if (input.ackOf !== undefined) message.ackOf = input.ackOf;
   if (input.meta !== undefined) message.meta = input.meta;
-  const traceparent = getTraceparent();
-  if (traceparent !== undefined) message.traceparent = traceparent;
+  const tc = getTraceContext();
+  if (tc.traceparent !== undefined) message.traceparent = tc.traceparent;
+  if (tc.tracestate !== undefined) message.tracestate = tc.tracestate;
   return message;
 }
 

--- a/src/cli/commands/outside.ts
+++ b/src/cli/commands/outside.ts
@@ -38,6 +38,10 @@ import {
   writeState,
 } from '../../runner/index.js';
 import {
+  coordinationMessagesSent,
+  getTraceparent,
+} from '../../telemetry/index.js';
+import {
   appendInboxMessage,
   type CoordinationRunTarget,
   invalidArgs,
@@ -240,6 +244,7 @@ function handleOutsideInboxSend(root: Command) {
       'outside',
       message,
     );
+    coordinationMessagesSent.add(1, { type: message.type, sender: 'outside' });
 
     // Derive peer activity AFTER append so the snapshot reflects observed state
     // at the moment the message lands. Tolerates any errors silently — peer is
@@ -607,6 +612,8 @@ export function buildOutsideMessage(input: OutsideMessageInput): InboxMessage {
   };
   if (input.ackOf !== undefined) message.ackOf = input.ackOf;
   if (input.meta !== undefined) message.meta = input.meta;
+  const traceparent = getTraceparent();
+  if (traceparent !== undefined) message.traceparent = traceparent;
   return message;
 }
 

--- a/src/cli/commands/sdk-runtime.ts
+++ b/src/cli/commands/sdk-runtime.ts
@@ -213,16 +213,35 @@ export async function createSdkRuntime(
   const cleanup = async () => {
     process.removeListener('SIGINT', sigintHandler);
     delete process.env.NODE_NO_WARNINGS;
-    // When telemetry is active, give the CLI's OTel batch exporter time to
-    // flush its pending spans (including the session root span) before we
-    // terminate the process.
+    // When telemetry is active, give the Copilot CLI subprocess's OTel batch
+    // exporter time to flush its pending spans (including its session root span)
+    // before we terminate it. The wait is bounded + tunable via
+    // MINIH_TELEMETRY_FLUSH_MS (default 1500ms; 0 disables). The minih process's
+    // own spans flush deterministically via shutdownTelemetry(); this settle is
+    // only for the subprocess exporter, which we can't forceFlush() directly.
     if (process.env.MINIH_TELEMETRY === 'true') {
-      await new Promise((r) => setTimeout(r, 5000));
+      const flushMs = resolveFlushMs(process.env.MINIH_TELEMETRY_FLUSH_MS);
+      if (flushMs > 0) {
+        await new Promise((r) => setTimeout(r, flushMs));
+      }
     }
     await client.stop().catch(() => {});
   };
 
   return { adapter, validateModelConfig, cleanup };
+}
+
+/**
+ * Resolve the telemetry flush settle window (ms) from MINIH_TELEMETRY_FLUSH_MS.
+ * Default 1500ms; clamped to [0, 30000]. Non-numeric → default.
+ */
+function resolveFlushMs(raw: string | undefined): number {
+  const DEFAULT = 1500;
+  const MAX = 30_000;
+  if (raw === undefined || raw === '') return DEFAULT;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT;
+  return Math.min(Math.floor(n), MAX);
 }
 
 /** Pick the closest known model id by Levenshtein distance — null if no plausible match. */

--- a/src/cli/commands/sdk-runtime.ts
+++ b/src/cli/commands/sdk-runtime.ts
@@ -100,6 +100,20 @@ export async function createSdkRuntime(
   // Suppress Node.js ExperimentalWarning in SDK subprocess (SQLite warning)
   process.env.NODE_NO_WARNINGS = '1';
 
+  // Telemetry flush reliability: the SDK spawns the Copilot CLI inheriting our
+  // process env. The CLI's long-lived `invoke_agent` root span ends last and
+  // sits in the batch processor's pending queue; `client.stop()` SIGTERMs the
+  // subprocess, which can kill it before that final batch is exported (orphaned
+  // SDK spans). Shrinking the standard OTel batch schedule delay makes the
+  // subprocess export frequently, so the root span is flushed within a few
+  // hundred ms of ending — well before stop(). Deterministic, unlike a sleep.
+  if (
+    process.env.MINIH_TELEMETRY === 'true' &&
+    process.env.OTEL_BSP_SCHEDULE_DELAY === undefined
+  ) {
+    process.env.OTEL_BSP_SCHEDULE_DELAY = '500';
+  }
+
   // Create client + adapter (DD13: pass onGetTraceContext for trace stitching)
   const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   const sdkClient = new (

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,7 @@ import {
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import {
+  contextFromTraceparent,
   getParentContext,
   initTelemetry,
   shutdownTelemetry,
@@ -46,6 +47,7 @@ export function createMinihMcpServer(context: McpServerContext): Server {
       context,
       request.params.name,
       request.params.arguments ?? {},
+      request.params._meta,
     ),
   );
 
@@ -72,6 +74,7 @@ export function dispatchToolCall(
   context: McpServerContext,
   name: string,
   args: Record<string, unknown>,
+  requestMeta?: Record<string, unknown>,
 ): Promise<CallToolResult> {
   const toolName = normalizeMcpToolName(name);
   if (toolName === null) {
@@ -82,33 +85,51 @@ export function dispatchToolCall(
     );
   }
 
-  return dispatchNormalizedToolCall(context, toolName, args).catch((error) => {
-    if (error instanceof McpToolError) {
-      return toCallToolResult(errorResult(error));
-    }
-    return toCallToolResult(
-      errorResult(new McpToolError('MCP_INTERNAL_ERROR', 'MCP tool failed')),
-    );
-  });
+  return dispatchNormalizedToolCall(context, toolName, args, requestMeta).catch(
+    (error) => {
+      if (error instanceof McpToolError) {
+        return toCallToolResult(errorResult(error));
+      }
+      return toCallToolResult(
+        errorResult(new McpToolError('MCP_INTERNAL_ERROR', 'MCP tool failed')),
+      );
+    },
+  );
 }
 
 async function dispatchNormalizedToolCall(
   context: McpServerContext,
   toolName: NonNullable<ReturnType<typeof normalizeMcpToolName>>,
   args: Record<string, unknown>,
+  requestMeta?: Record<string, unknown>,
 ): Promise<CallToolResult> {
-  // OPP-1: one span per MCP tool call, rooted under the run's execution span via
-  // the TRACEPARENT injected at spawn (getParentContext / DD11). No-op when
-  // telemetry is disabled (noop tracer).
+  // One span per MCP tool call. Per-call trace context (SEP-414): the Copilot
+  // CLI injects the invoking `execute_tool` span's `traceparent` into
+  // `params._meta`, so we nest this span directly under it. Fall back to the
+  // spawn-time run context (DD11) when absent (telemetry off / older CLI).
+  // No-op when telemetry is disabled (noop tracer).
+  const perCallParent = contextFromTraceparent(
+    typeof requestMeta?.traceparent === 'string'
+      ? requestMeta.traceparent
+      : undefined,
+  );
+  const spawnParent = getParentContext();
+  const parent = perCallParent ?? spawnParent;
+  const contextSource = perCallParent
+    ? 'per-call'
+    : spawnParent
+      ? 'spawn'
+      : 'none';
   return withSpan(
     `minih.mcp.${toolName}`,
     async (span) => {
       span.setAttribute('mcp.tool', toolName);
       span.setAttribute('agent.slug', context.agentSlug);
+      span.setAttribute('mcp.trace_context', contextSource);
       return runMcpTool(context, toolName, args);
     },
     undefined,
-    getParentContext(),
+    parent,
   );
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,12 @@ import {
   ListToolsRequestSchema,
   type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import {
+  getParentContext,
+  initTelemetry,
+  shutdownTelemetry,
+  withSpan,
+} from '../telemetry/index.js';
 import { loadMcpContext, type McpServerContext } from './context.js';
 import { coordinationStatus } from './tools/coordination-status.js';
 import { inboxAck, inboxList, inboxSend } from './tools/inbox.js';
@@ -91,6 +97,26 @@ async function dispatchNormalizedToolCall(
   toolName: NonNullable<ReturnType<typeof normalizeMcpToolName>>,
   args: Record<string, unknown>,
 ): Promise<CallToolResult> {
+  // OPP-1: one span per MCP tool call, rooted under the run's execution span via
+  // the TRACEPARENT injected at spawn (getParentContext / DD11). No-op when
+  // telemetry is disabled (noop tracer).
+  return withSpan(
+    `minih.mcp.${toolName}`,
+    async (span) => {
+      span.setAttribute('mcp.tool', toolName);
+      span.setAttribute('agent.slug', context.agentSlug);
+      return runMcpTool(context, toolName, args);
+    },
+    undefined,
+    getParentContext(),
+  );
+}
+
+async function runMcpTool(
+  context: McpServerContext,
+  toolName: NonNullable<ReturnType<typeof normalizeMcpToolName>>,
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
   switch (toolName) {
     case 'inbox_list':
       return toCallToolResult(await inboxList(context, args));
@@ -119,9 +145,12 @@ export function applyProcessMarker(context: McpServerContext): void {
 
 export function installSignalHandlers(server: Server): () => void {
   const shutdown = (): void => {
-    void server.close().finally(() => {
-      process.exit(0);
-    });
+    void server
+      .close()
+      .then(() => shutdownTelemetry())
+      .finally(() => {
+        process.exit(0);
+      });
   };
   process.once('SIGTERM', shutdown);
   process.once('SIGINT', shutdown);
@@ -134,6 +163,9 @@ export function installSignalHandlers(server: Server): () => void {
 export async function runStdioMcpServer(
   env: Record<string, string | undefined> = process.env,
 ): Promise<void> {
+  // OPP-1: initialize telemetry for the coordination MCP subprocess. No-op unless
+  // MINIH_TELEMETRY=true was injected at spawn; reads TRACEPARENT for trace stitch.
+  initTelemetry();
   const { server } = createMinihMcpServerFromEnv(env);
   installSignalHandlers(server);
   await server.connect(new StdioServerTransport());

--- a/src/mcp/spawn.ts
+++ b/src/mcp/spawn.ts
@@ -6,6 +6,7 @@ import {
   inboxLanePath,
   stateFilePath,
 } from '../runner/folder.js';
+import { getTraceparent, isTelemetryEnabled } from '../telemetry/index.js';
 import { MCP_ENV_KEYS } from './context.js';
 import { MINIH_COORDINATION_SERVER_NAME } from './types.js';
 
@@ -65,9 +66,26 @@ export function buildInsideMcpServerConfig(
         [MCP_ENV_KEYS.agentSlug]: options.agentSlug,
         [MCP_ENV_KEYS.agentsDir]: agentsDir,
         [MCP_ENV_KEYS.processMarker]: `minih-mcp-${options.runId}`,
+        ...buildTelemetryEnv(),
       },
     },
   };
+}
+
+/**
+ * Telemetry passthrough for the spawned MCP coordination server (OPP-1).
+ * Only emitted when the parent process has telemetry enabled, so the server is
+ * a true no-op when telemetry is off. `TRACEPARENT` carries the active span
+ * (run.execution) so MCP tool spans (DD11) root into the run's distributed trace.
+ */
+function buildTelemetryEnv(): Record<string, string> {
+  if (!isTelemetryEnabled()) return {};
+  const env: Record<string, string> = { MINIH_TELEMETRY: 'true' };
+  const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (otlpEndpoint) env.OTEL_EXPORTER_OTLP_ENDPOINT = otlpEndpoint;
+  const traceparent = getTraceparent();
+  if (traceparent) env.TRACEPARENT = traceparent;
+  return env;
 }
 
 export function resolveInsideMcpServerEntry(

--- a/src/mcp/tools/inbox.ts
+++ b/src/mcp/tools/inbox.ts
@@ -8,6 +8,10 @@ import {
 } from '../../runner/inbox-poll.js';
 import type { InboxMessage, Side } from '../../runner/types.js';
 import { ulid } from '../../runner/ulid.js';
+import {
+  coordinationMessagesSent,
+  getTraceparent,
+} from '../../telemetry/index.js';
 import type { McpServerContext } from '../context.js';
 import {
   type InboxListInput,
@@ -106,7 +110,11 @@ export function inboxSend(
   // (inside-acks-inside) is intentionally allowed for thread continuation.
   if (ackOf !== undefined) message.ackOf = ackOf;
 
+  const traceparent = getTraceparent();
+  if (traceparent !== undefined) message.traceparent = traceparent;
+
   appendMessage(lanePath(context, 'inside'), message);
+  coordinationMessagesSent.add(1, { type: message.type, sender: 'inside' });
   return jsonResult({ message });
 }
 
@@ -142,7 +150,10 @@ export function inboxAck(
     ts: new Date().toISOString(),
     ackOf: msgId,
   };
+  const ackTraceparent = getTraceparent();
+  if (ackTraceparent !== undefined) ack.traceparent = ackTraceparent;
   appendMessage(lanePath(context, 'inside'), ack);
+  coordinationMessagesSent.add(1, { type: 'ack', sender: 'inside' });
   return jsonResult({ acked: true, alreadyAcked: false, msgId, ack });
 }
 
@@ -210,6 +221,22 @@ function parseMessageLine(
   }
   if (value.meta !== undefined) {
     message.meta = requireRecord(value.meta, 'meta');
+  }
+  if (value.traceparent !== undefined) {
+    if (typeof value.traceparent !== 'string') {
+      throw corruptInbox(
+        `inbox message at line ${lineNumber} has invalid traceparent`,
+      );
+    }
+    message.traceparent = value.traceparent;
+  }
+  if (value.tracestate !== undefined) {
+    if (typeof value.tracestate !== 'string') {
+      throw corruptInbox(
+        `inbox message at line ${lineNumber} has invalid tracestate`,
+      );
+    }
+    message.tracestate = value.tracestate;
   }
   return message;
 }

--- a/src/mcp/tools/inbox.ts
+++ b/src/mcp/tools/inbox.ts
@@ -11,7 +11,7 @@ import { ulid } from '../../runner/ulid.js';
 import {
   addSpanAttributes,
   coordinationMessagesSent,
-  getTraceparent,
+  getTraceContext,
   isVerboseEnabled,
 } from '../../telemetry/index.js';
 import type { McpServerContext } from '../context.js';
@@ -112,8 +112,9 @@ export function inboxSend(
   // (inside-acks-inside) is intentionally allowed for thread continuation.
   if (ackOf !== undefined) message.ackOf = ackOf;
 
-  const traceparent = getTraceparent();
-  if (traceparent !== undefined) message.traceparent = traceparent;
+  const tc = getTraceContext();
+  if (tc.traceparent !== undefined) message.traceparent = tc.traceparent;
+  if (tc.tracestate !== undefined) message.tracestate = tc.tracestate;
 
   appendMessage(lanePath(context, 'inside'), message);
   coordinationMessagesSent.add(1, { type: message.type, sender: 'inside' });
@@ -161,8 +162,9 @@ export function inboxAck(
     ts: new Date().toISOString(),
     ackOf: msgId,
   };
-  const ackTraceparent = getTraceparent();
-  if (ackTraceparent !== undefined) ack.traceparent = ackTraceparent;
+  const ackTc = getTraceContext();
+  if (ackTc.traceparent !== undefined) ack.traceparent = ackTc.traceparent;
+  if (ackTc.tracestate !== undefined) ack.tracestate = ackTc.tracestate;
   appendMessage(lanePath(context, 'inside'), ack);
   coordinationMessagesSent.add(1, { type: 'ack', sender: 'inside' });
   return jsonResult({ acked: true, alreadyAcked: false, msgId, ack });

--- a/src/mcp/tools/inbox.ts
+++ b/src/mcp/tools/inbox.ts
@@ -9,8 +9,10 @@ import {
 import type { InboxMessage, Side } from '../../runner/types.js';
 import { ulid } from '../../runner/ulid.js';
 import {
+  addSpanAttributes,
   coordinationMessagesSent,
   getTraceparent,
+  isVerboseEnabled,
 } from '../../telemetry/index.js';
 import type { McpServerContext } from '../context.js';
 import {
@@ -115,6 +117,15 @@ export function inboxSend(
 
   appendMessage(lanePath(context, 'inside'), message);
   coordinationMessagesSent.add(1, { type: message.type, sender: 'inside' });
+  // Enrich the active minih.mcp.inbox_send dispatch span with message content.
+  addSpanAttributes({
+    'message.id': message.id,
+    'message.type': message.type,
+    'message.subject': subject,
+    'message.body.length': body.length,
+    // Full body only in verbose mode (DD3 — privacy-safe default).
+    ...(isVerboseEnabled() ? { 'message.body': body } : {}),
+  });
   return jsonResult({ message });
 }
 

--- a/src/mcp/tools/state.ts
+++ b/src/mcp/tools/state.ts
@@ -10,6 +10,10 @@ import {
   writeState,
 } from '../../runner/state.js';
 import type { InsideState, Side, SideState } from '../../runner/types.js';
+import {
+  addSpanAttributes,
+  coordinationStateTransitions,
+} from '../../telemetry/index.js';
 import type { McpServerContext } from '../context.js';
 import { jsonResult, McpToolError, type McpToolResult } from '../types.js';
 import { insideStateSchemaPath } from './inside-state-schema.js';
@@ -111,6 +115,17 @@ export function stateTransition(
       reason: parseOptionalReason(input.reason),
     });
     writeState(location, 'inside', next);
+
+    // OPP-3/OPP-4: enrich the dispatch span (minih.mcp.state_transition) and
+    // record the transition counter. Only on a real transition.
+    addSpanAttributes({
+      'state.from': current.status,
+      'state.to': next.status,
+    });
+    coordinationStateTransitions.add(1, {
+      from: current.status,
+      to: next.status,
+    });
 
     return jsonResult({
       state: next,

--- a/src/runner/inbox-forwarder.ts
+++ b/src/runner/inbox-forwarder.ts
@@ -1,5 +1,11 @@
 import * as fs from 'node:fs';
+import type { Context } from '@opentelemetry/api';
 import type { SessionSender } from '../adapter/events.js';
+import {
+  coordinationMessagesReceived,
+  spanContextFromTraceparent,
+  withSpan,
+} from '../telemetry/index.js';
 import {
   type FileWatcher,
   type WatchFactory,
@@ -24,6 +30,12 @@ export interface InboxForwarderOptions {
   debounceMs?: number;
   onError?: (error: Error) => void;
   watchFactory?: WatchFactory;
+  /**
+   * Run-execution span context for rooting receive spans (OPP-3). Forwarders
+   * fire from fs.watch callbacks that break the async context chain, so the
+   * caller captures the execution context and passes it here.
+   */
+  parentContext?: Context;
 }
 
 export interface InboxDrainResult {
@@ -186,7 +198,7 @@ async function drainOnce(
 
   for (const line of completeLinesFrom(content, startOffset)) {
     const message = parseInboxMessage(line.text, line.startOffset);
-    await options.sender.send(renderInboxMessageForAgent(message));
+    await deliverMessage(options, message);
     if (options.commitProgress !== 'manual') {
       updateForwarderWatermark(options, (current) =>
         withInboxOffset(current, line.endOffset),
@@ -203,6 +215,31 @@ async function drainOnce(
     sent,
     stoppedOnTornLine: cursor < content.length,
   };
+}
+
+/**
+ * Deliver one outside message to the agent inside a `minih.coordination.message_received`
+ * span (OPP-2/OPP-3). The span LINKS to the producer's span (from the message's
+ * `traceparent`) — async messaging connects sender↔receiver via links, not parent/child.
+ * Rooted under the run's execution context (`options.parentContext`).
+ */
+async function deliverMessage(
+  options: InboxForwarderOptions,
+  message: InboxMessage,
+): Promise<void> {
+  const producer = spanContextFromTraceparent(message.traceparent);
+  await withSpan(
+    'minih.coordination.message_received',
+    async (span) => {
+      span.setAttribute('message.id', message.id);
+      span.setAttribute('message.type', message.type);
+      span.setAttribute('message.sender', message.sender);
+      await options.sender.send(renderInboxMessageForAgent(message));
+    },
+    producer ? { links: [{ context: producer }] } : undefined,
+    options.parentContext,
+  );
+  coordinationMessagesReceived.add(1, { type: message.type });
 }
 
 function watchOptions(
@@ -302,6 +339,25 @@ function parseInboxMessage(text: string, offset: number): InboxMessage {
       throw new InvalidInboxMessageError(offset, 'meta must be an object');
     }
     message.meta = meta as Record<string, unknown>;
+  }
+
+  const traceparent = record.traceparent;
+  if (traceparent !== undefined) {
+    if (typeof traceparent !== 'string') {
+      throw new InvalidInboxMessageError(
+        offset,
+        'traceparent must be a string',
+      );
+    }
+    message.traceparent = traceparent;
+  }
+
+  const tracestate = record.tracestate;
+  if (tracestate !== undefined) {
+    if (typeof tracestate !== 'string') {
+      throw new InvalidInboxMessageError(offset, 'tracestate must be a string');
+    }
+    message.tracestate = tracestate;
   }
 
   return message;

--- a/src/runner/inbox-forwarder.ts
+++ b/src/runner/inbox-forwarder.ts
@@ -3,6 +3,7 @@ import type { Context } from '@opentelemetry/api';
 import type { SessionSender } from '../adapter/events.js';
 import {
   coordinationMessagesReceived,
+  isVerboseEnabled,
   spanContextFromTraceparent,
   withSpan,
 } from '../telemetry/index.js';
@@ -234,6 +235,12 @@ async function deliverMessage(
       span.setAttribute('message.id', message.id);
       span.setAttribute('message.type', message.type);
       span.setAttribute('message.sender', message.sender);
+      span.setAttribute('message.subject', message.subject);
+      span.setAttribute('message.body.length', message.body.length);
+      // Full body content only in verbose mode (DD3 — privacy-safe default).
+      if (isVerboseEnabled()) {
+        span.setAttribute('message.body', message.body);
+      }
       await options.sender.send(renderInboxMessageForAgent(message));
     },
     producer ? { links: [{ context: producer }] } : undefined,

--- a/src/runner/inbox-poll.ts
+++ b/src/runner/inbox-poll.ts
@@ -411,6 +411,24 @@ function parseMessageLine(
     }
     message.meta = value.meta;
   }
+  if (value.traceparent !== undefined) {
+    if (typeof value.traceparent !== 'string') {
+      throw new InboxPollError(
+        'INBOX_POLL_CORRUPT',
+        `inbox message at line ${lineNumber} has invalid traceparent`,
+      );
+    }
+    message.traceparent = value.traceparent;
+  }
+  if (value.tracestate !== undefined) {
+    if (typeof value.tracestate !== 'string') {
+      throw new InboxPollError(
+        'INBOX_POLL_CORRUPT',
+        `inbox message at line ${lineNumber} has invalid tracestate`,
+      );
+    }
+    message.tracestate = value.tracestate;
+  }
   return message;
 }
 

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -13,7 +13,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { context } from '@opentelemetry/api';
+import { type Context, context } from '@opentelemetry/api';
 import { withDeadline } from '../adapter/deadline.js';
 import type {
   AgentEvent,
@@ -1192,6 +1192,10 @@ export async function runAgent(
 
       let inboxForwarder: InboxForwarder | null = null;
       let stateForwarder: StateForwarder | null = null;
+      // Captured inside the execution span so forwarder spans (which fire from
+      // fs.watch callbacks that break the async context chain) root under
+      // minih.run.execution (OPP-3).
+      let executionContext: Context | undefined;
       const forwarderErrors: Error[] = [];
       const pendingForwarderCount = (): number =>
         (inboxForwarder?.pendingCount() ?? 0) +
@@ -1231,6 +1235,7 @@ export async function runAgent(
           sender,
           commitProgress: 'manual' as const,
           onError: handleForwarderError,
+          ...(executionContext && { parentContext: executionContext }),
         };
         inboxForwarder = createInboxForwarder(forwarderOptions);
         stateForwarder = createStateForwarder(forwarderOptions);
@@ -1261,6 +1266,9 @@ export async function runAgent(
           async (execSpan) => {
             execSpan.setAttribute('agent.slug', definition.slug);
             execSpan.setAttribute('timeout_ms', timeoutMs);
+            // Capture this span's context so coordination forwarder spans can
+            // root under it from broken-async-chain fs.watch callbacks (OPP-3).
+            executionContext = captureContext();
             log.info(`Agent run started: ${definition.slug}`, {
               'agent.slug': definition.slug,
               model: config.model ?? '',

--- a/src/runner/state-forwarder.ts
+++ b/src/runner/state-forwarder.ts
@@ -1,6 +1,8 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import type { Context } from '@opentelemetry/api';
 import type { SessionSender } from '../adapter/events.js';
+import { withSpan } from '../telemetry/index.js';
 import {
   type FileWatcher,
   type WatchFactory,
@@ -26,6 +28,8 @@ export interface StateForwarderOptions {
   debounceMs?: number;
   onError?: (error: Error) => void;
   watchFactory?: WatchFactory;
+  /** Run-execution span context for rooting state-change spans (OPP-3). */
+  parentContext?: Context;
 }
 
 export interface StateDrainResult {
@@ -184,7 +188,15 @@ async function drainOnce(
     return { sent: false, fingerprint: nextFingerprint };
   }
 
-  await options.sender.send(renderStateChangeForAgent(state));
+  await withSpan(
+    'minih.coordination.state_change',
+    async (span) => {
+      span.setAttribute('state.status', state.status);
+      await options.sender.send(renderStateChangeForAgent(state));
+    },
+    undefined,
+    options.parentContext,
+  );
   if (options.commitProgress !== 'manual') {
     updateForwarderWatermark(options, (current) =>
       withStateFingerprint(current, nextFingerprint),

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -365,6 +365,13 @@ export interface InboxMessage {
   /** ULID of a message this message acknowledges. */
   ackOf?: string;
   meta?: Record<string, unknown>;
+  /**
+   * W3C `traceparent` of the producer's active span at send time (telemetry on).
+   * Enables the consumer (forwarder) to link delivery to the producer's trace.
+   */
+  traceparent?: string;
+  /** W3C `tracestate` companion to `traceparent` (optional). */
+  tracestate?: string;
 }
 
 /** Outside state — mirrors `src/schemas/outside-state.json`. */

--- a/src/schemas/inbox-message.json
+++ b/src/schemas/inbox-message.json
@@ -11,7 +11,12 @@
     "body": { "type": "string", "minLength": 0, "maxLength": 10000 },
     "ts": { "type": "string", "format": "date-time" },
     "ackOf": { "type": "string", "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$" },
-    "meta": { "type": "object" }
+    "meta": { "type": "object" },
+    "traceparent": {
+      "type": "string",
+      "pattern": "^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$"
+    },
+    "tracestate": { "type": "string", "maxLength": 512 }
   },
   "additionalProperties": false
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -19,6 +19,9 @@ export type { Logger, LogLevel } from './logger.js';
 export { createLogger } from './logger.js';
 // Metrics
 export {
+  coordinationMessagesReceived,
+  coordinationMessagesSent,
+  coordinationStateTransitions,
   eventCount,
   promptTokens,
   runCount,
@@ -29,11 +32,13 @@ export {
 } from './metrics.js';
 // Spans
 export {
+  addSpanAttributes,
   BaggageCopyProcessor,
   captureContext,
   getTraceparent,
   runInContext,
   setBaggage,
+  spanContextFromTraceparent,
   withSpan,
   withSpanSync,
 } from './spans.js';

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -35,6 +35,8 @@ export {
   addSpanAttributes,
   BaggageCopyProcessor,
   captureContext,
+  contextFromTraceparent,
+  getTraceContext,
   getTraceparent,
   runInContext,
   setBaggage,

--- a/src/telemetry/init.ts
+++ b/src/telemetry/init.ts
@@ -120,9 +120,20 @@ export function initTelemetry(): void {
   // DD11: Extract TRACEPARENT/TRACESTATE from env for cross-process stitching.
   // Store as parent context — root spans should use getParentContext() so they
   // appear as children of the calling process's trace.
-  const parentContext = propagation.extract(context.active(), process.env);
-  if (parentContext !== context.active()) {
-    extractedParentContext = parentContext;
+  //
+  // Env vars are UPPERCASE by convention, but the W3C trace-context propagator
+  // reads LOWERCASE carrier keys (`traceparent`/`tracestate`). Passing
+  // `process.env` directly therefore never matches. Build a normalized carrier
+  // (accept either casing) so cross-process stitching actually works.
+  const traceparent = process.env.TRACEPARENT ?? process.env.traceparent;
+  const tracestate = process.env.TRACESTATE ?? process.env.tracestate;
+  if (traceparent) {
+    const carrier: Record<string, string> = { traceparent };
+    if (tracestate) carrier.tracestate = tracestate;
+    const parentContext = propagation.extract(context.active(), carrier);
+    if (parentContext !== context.active()) {
+      extractedParentContext = parentContext;
+    }
   }
 }
 

--- a/src/telemetry/metrics.ts
+++ b/src/telemetry/metrics.ts
@@ -117,3 +117,54 @@ export const sessionDuration = {
     _sessionDuration.record(value, attrs);
   },
 };
+
+/** Coordination inbox messages sent (attrs: type, sender). */
+let _coordinationMessagesSent: Counter | undefined;
+export const coordinationMessagesSent = {
+  add(value: number, attrs?: Attributes) {
+    if (!_coordinationMessagesSent) {
+      _coordinationMessagesSent = getMeter().createCounter(
+        'minih.coordination.messages_sent',
+        {
+          description: 'Coordination inbox messages sent',
+          unit: '{messages}',
+        },
+      );
+    }
+    _coordinationMessagesSent.add(value, attrs);
+  },
+};
+
+/** Coordination inbox messages delivered to the inside agent (attrs: type). */
+let _coordinationMessagesReceived: Counter | undefined;
+export const coordinationMessagesReceived = {
+  add(value: number, attrs?: Attributes) {
+    if (!_coordinationMessagesReceived) {
+      _coordinationMessagesReceived = getMeter().createCounter(
+        'minih.coordination.messages_received',
+        {
+          description: 'Coordination inbox messages delivered to the agent',
+          unit: '{messages}',
+        },
+      );
+    }
+    _coordinationMessagesReceived.add(value, attrs);
+  },
+};
+
+/** Coordination inside-state transitions (attrs: from, to). */
+let _coordinationStateTransitions: Counter | undefined;
+export const coordinationStateTransitions = {
+  add(value: number, attrs?: Attributes) {
+    if (!_coordinationStateTransitions) {
+      _coordinationStateTransitions = getMeter().createCounter(
+        'minih.coordination.state_transitions',
+        {
+          description: 'Coordination inside-state transitions',
+          unit: '{transitions}',
+        },
+      );
+    }
+    _coordinationStateTransitions.add(value, attrs);
+  },
+};

--- a/src/telemetry/spans.ts
+++ b/src/telemetry/spans.ts
@@ -7,12 +7,15 @@
  */
 
 import {
+  type Attributes,
   type Context,
   context,
   propagation,
   type Span,
+  type SpanContext,
   type SpanOptions,
   SpanStatusCode,
+  TraceFlags,
   trace,
 } from '@opentelemetry/api';
 import type {
@@ -57,13 +60,17 @@ export async function withSpan<T>(
 
 /**
  * Start a synchronous span with the minih tracer.
+ * If parentContext is provided, the span is created as a child of that context
+ * (used when the active async context has been broken, e.g. fs.watch callbacks).
  */
 export function withSpanSync<T>(
   name: string,
   fn: (span: Span) => T,
   options?: SpanOptions,
+  parentContext?: Context,
 ): T {
-  return tracer.startActiveSpan(name, options ?? {}, (span) => {
+  const opts = options ?? {};
+  const callback = (span: Span): T => {
     try {
       const result = fn(span);
       return result;
@@ -76,7 +83,11 @@ export function withSpanSync<T>(
     } finally {
       span.end();
     }
-  });
+  };
+  if (parentContext) {
+    return tracer.startActiveSpan(name, opts, parentContext, callback);
+  }
+  return tracer.startActiveSpan(name, opts, callback);
 }
 
 /**
@@ -101,6 +112,16 @@ export function captureContext(): Context {
 }
 
 /**
+ * Set attributes on the currently-active span, if any. No-op when there is no
+ * recording span (telemetry off or outside any span). Useful for enriching a
+ * span created by an outer wrapper (e.g. the MCP dispatch span) from within an
+ * inner function without creating a nested span.
+ */
+export function addSpanAttributes(attributes: Attributes): void {
+  trace.getActiveSpan()?.setAttributes(attributes);
+}
+
+/**
  * Serialize the current active span context as a W3C traceparent string.
  * Returns undefined if there is no active span or the context is invalid.
  * Format: 00-{traceId}-{spanId}-{traceFlags}
@@ -113,6 +134,35 @@ export function getTraceparent(): string | undefined {
     return undefined;
   const flags = ctx.traceFlags.toString(16).padStart(2, '0');
   return `00-${ctx.traceId}-${ctx.spanId}-${flags}`;
+}
+
+/**
+ * Parse a W3C traceparent string into a remote SpanContext, suitable for use as
+ * a span link target (async messaging: link producer↔consumer across processes).
+ * Manual parse — does not depend on a globally-registered propagator, so it works
+ * even when the OTel SDK is not initialized in the current process.
+ * Returns undefined for any malformed input.
+ */
+export function spanContextFromTraceparent(
+  traceparent: string | undefined,
+): SpanContext | undefined {
+  if (!traceparent) return undefined;
+  const match = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/.exec(
+    traceparent,
+  );
+  if (!match) return undefined;
+  const [, traceId, spanId, flagsHex] = match;
+  if (
+    traceId === '00000000000000000000000000000000' ||
+    spanId === '0000000000000000'
+  ) {
+    return undefined;
+  }
+  const traceFlags =
+    Number.parseInt(flagsHex, 16) & TraceFlags.SAMPLED
+      ? TraceFlags.SAMPLED
+      : TraceFlags.NONE;
+  return { traceId, spanId, traceFlags, isRemote: true };
 }
 
 /**

--- a/src/telemetry/spans.ts
+++ b/src/telemetry/spans.ts
@@ -11,6 +11,7 @@ import {
   type Context,
   context,
   propagation,
+  ROOT_CONTEXT,
   type Span,
   type SpanContext,
   type SpanOptions,
@@ -137,6 +138,23 @@ export function getTraceparent(): string | undefined {
 }
 
 /**
+ * W3C trace context (`traceparent` + `tracestate`) of the active span, for
+ * stamping on outbound messages. Uses the global propagator so both keys are
+ * captured per W3C Trace Context. Empty object when there is no active span.
+ */
+export function getTraceContext(): {
+  traceparent?: string;
+  tracestate?: string;
+} {
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+  const out: { traceparent?: string; tracestate?: string } = {};
+  if (carrier.traceparent) out.traceparent = carrier.traceparent;
+  if (carrier.tracestate) out.tracestate = carrier.tracestate;
+  return out;
+}
+
+/**
  * Parse a W3C traceparent string into a remote SpanContext, suitable for use as
  * a span link target (async messaging: link producer↔consumer across processes).
  * Manual parse — does not depend on a globally-registered propagator, so it works
@@ -163,6 +181,25 @@ export function spanContextFromTraceparent(
       ? TraceFlags.SAMPLED
       : TraceFlags.NONE;
   return { traceId, spanId, traceFlags, isRemote: true };
+}
+
+/**
+ * Build a parent Context from a W3C traceparent string (e.g. a per-call
+ * `_meta.traceparent` from an MCP `tools/call`, per SEP-414). Pass the result
+ * to `withSpan`/`withSpanSync` so the new span nests under the remote parent
+ * (the caller's `execute_tool` span). Returns undefined for malformed input.
+ *
+ * `tracestate` is accepted for forward-compatibility but not attached to the
+ * span context — nesting only needs trace/span ids; the value is preserved on
+ * the message envelope instead.
+ */
+export function contextFromTraceparent(
+  traceparent: string | undefined,
+  _tracestate?: string,
+): Context | undefined {
+  const spanContext = spanContextFromTraceparent(traceparent);
+  if (!spanContext) return undefined;
+  return trace.setSpanContext(ROOT_CONTEXT, spanContext);
 }
 
 /**

--- a/test/mcp/inbox.test.ts
+++ b/test/mcp/inbox.test.ts
@@ -351,6 +351,24 @@ describe('inboxSend', () => {
     const result = await listed();
     expect(result?.messages?.[0]).toMatchObject({ traceparent });
   });
+
+  it('round-trips traceparent AND tracestate through inbox_list', async () => {
+    const traceparent =
+      '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    const tracestate = 'vendorA=t61rcWkgMzE,vendorB=abc';
+    writeMessage('outside', {
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FAW',
+      sender: 'outside',
+      type: 'task',
+      subject: 'Traced with state',
+      body: 'do the thing',
+      ts: '2026-04-26T00:00:00Z',
+      traceparent,
+      tracestate,
+    });
+    const result = await listed();
+    expect(result?.messages?.[0]).toMatchObject({ traceparent, tracestate });
+  });
 });
 
 describe('inboxAck', () => {

--- a/test/mcp/inbox.test.ts
+++ b/test/mcp/inbox.test.ts
@@ -335,6 +335,22 @@ describe('inboxSend', () => {
     expect(lines).toHaveLength(20);
     expect(lines.map((line) => JSON.parse(line))).toHaveLength(20);
   });
+
+  it('round-trips a traceparent stamped on an outside message through inbox_list', async () => {
+    const traceparent =
+      '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    writeMessage('outside', {
+      id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      sender: 'outside',
+      type: 'task',
+      subject: 'Traced request',
+      body: 'do the thing',
+      ts: '2026-04-26T00:00:00Z',
+      traceparent,
+    });
+    const result = await listed();
+    expect(result?.messages?.[0]).toMatchObject({ traceparent });
+  });
 });
 
 describe('inboxAck', () => {

--- a/test/mcp/server-dispatch.test.ts
+++ b/test/mcp/server-dispatch.test.ts
@@ -68,6 +68,24 @@ describe('MCP server dispatcher', () => {
     });
   });
 
+  it('accepts per-call _meta.traceparent (SEP-414) without affecting the result', async () => {
+    // Per-call trace context is used to parent the span; it must not change the
+    // tool result or throw. (Span nesting itself is verified end-to-end via LGTM.)
+    const result = await dispatchToolCall(
+      context,
+      'inbox_send',
+      { subject: 'Traced', body: 'Body' },
+      {
+        traceparent: '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+      },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({
+      message: { sender: 'inside', subject: 'Traced', body: 'Body' },
+    });
+  });
+
   it('dispatches typed tool errors through _meta.code', async () => {
     const result = await dispatchToolCall(context, 'inbox_ack', {
       msgId: 'missing',

--- a/test/mcp/spawn.test.ts
+++ b/test/mcp/spawn.test.ts
@@ -102,6 +102,52 @@ describe('buildInsideMcpServerConfig', () => {
       }),
     ).toThrow(/command/);
   });
+
+  it('omits telemetry env when telemetry is disabled (OPP-1)', () => {
+    const prev = process.env.MINIH_TELEMETRY;
+    delete process.env.MINIH_TELEMETRY;
+    try {
+      const entry = buildInsideMcpServerConfig({
+        runId: 'run-123',
+        runDir: path.join(tmpDir, 'agents', 'code-review', 'runs', 'run-123'),
+        agentSlug: 'code-review',
+        agentsDir: path.join(tmpDir, 'agents'),
+        serverEntryPath: makeServerEntry('dist/mcp/server.js'),
+      })[MINIH_COORDINATION_SERVER_NAME];
+      expect(entry.env.MINIH_TELEMETRY).toBeUndefined();
+      expect(entry.env.OTEL_EXPORTER_OTLP_ENDPOINT).toBeUndefined();
+      expect(entry.env.TRACEPARENT).toBeUndefined();
+    } finally {
+      if (prev !== undefined) process.env.MINIH_TELEMETRY = prev;
+    }
+  });
+
+  it('injects telemetry env when telemetry is enabled (OPP-1)', () => {
+    const prevTel = process.env.MINIH_TELEMETRY;
+    const prevOtlp = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    process.env.MINIH_TELEMETRY = 'true';
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+    try {
+      const entry = buildInsideMcpServerConfig({
+        runId: 'run-123',
+        runDir: path.join(tmpDir, 'agents', 'code-review', 'runs', 'run-123'),
+        agentSlug: 'code-review',
+        agentsDir: path.join(tmpDir, 'agents'),
+        serverEntryPath: makeServerEntry('dist/mcp/server.js'),
+      })[MINIH_COORDINATION_SERVER_NAME];
+      expect(entry.env.MINIH_TELEMETRY).toBe('true');
+      expect(entry.env.OTEL_EXPORTER_OTLP_ENDPOINT).toBe(
+        'http://localhost:4318',
+      );
+      // TRACEPARENT only present when an active span exists; none in this unit test.
+    } finally {
+      if (prevTel !== undefined) process.env.MINIH_TELEMETRY = prevTel;
+      else delete process.env.MINIH_TELEMETRY;
+      if (prevOtlp !== undefined)
+        process.env.OTEL_EXPORTER_OTLP_ENDPOINT = prevOtlp;
+      else delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    }
+  });
 });
 
 describe('resolveInsideMcpServerEntry', () => {

--- a/test/runner/inbox-forwarder.test.ts
+++ b/test/runner/inbox-forwarder.test.ts
@@ -103,6 +103,18 @@ function message(id: string, subject: string, body = 'Body text') {
   })}\n`;
 }
 
+function tracedMessage(id: string, subject: string, traceparent: string) {
+  return `${JSON.stringify({
+    id,
+    sender: 'outside',
+    type: 'task',
+    subject,
+    body: 'Body text',
+    ts: '2026-04-26T00:00:00Z',
+    traceparent,
+  })}\n`;
+}
+
 function forwarder(testSender = sender()) {
   return createInboxForwarder({
     slug,
@@ -127,6 +139,20 @@ describe('inbox forwarder', () => {
     expect(readForwarderWatermark({ slug, agentsDir, runId }).value).toEqual(
       defaultForwarderWatermark(),
     );
+  });
+
+  it('forwards a message carrying a producer traceparent (link path) without error', async () => {
+    const traceparent =
+      '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    writeInbox([
+      tracedMessage('01ARZ3NDEKTSV4RRFFQ69G5FAV', 'Traced', traceparent),
+    ]);
+    const testSender = sender();
+    const result = await forwarder(testSender).drain();
+
+    expect(result.sent).toBe(1);
+    expect(testSender.prompts).toHaveLength(1);
+    expect(testSender.prompts[0]).toContain('Traced');
   });
 
   it('forwards complete outside inbox messages in order and advances byte offset', async () => {

--- a/test/telemetry/init.test.ts
+++ b/test/telemetry/init.test.ts
@@ -1,5 +1,7 @@
+import { trace } from '@opentelemetry/api';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  getParentContext,
   initTelemetry,
   isTelemetryEnabled,
   shutdownTelemetry,
@@ -12,6 +14,8 @@ describe('telemetry/init', () => {
   beforeEach(() => {
     delete process.env.MINIH_TELEMETRY;
     delete process.env.MINIH_TELEMETRY_VERBOSE;
+    delete process.env.TRACEPARENT;
+    delete process.env.TRACESTATE;
   });
 
   afterEach(async () => {
@@ -65,5 +69,23 @@ describe('telemetry/init', () => {
         throw new Error('test error');
       }),
     ).rejects.toThrow('test error');
+  });
+
+  it('getParentContext is undefined without TRACEPARENT', () => {
+    process.env.MINIH_TELEMETRY = 'true';
+    initTelemetry();
+    expect(getParentContext()).toBeUndefined();
+  });
+
+  it('extracts an UPPERCASE TRACEPARENT env var into the parent context (DD11)', () => {
+    process.env.MINIH_TELEMETRY = 'true';
+    process.env.TRACEPARENT =
+      '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    initTelemetry();
+    const parent = getParentContext();
+    expect(parent).toBeDefined();
+    const sc = parent ? trace.getSpanContext(parent) : undefined;
+    expect(sc?.traceId).toBe('0af7651916cd43dd8448eb211c80319c');
+    expect(sc?.spanId).toBe('b7ad6b7169203331');
   });
 });

--- a/test/telemetry/metrics.test.ts
+++ b/test/telemetry/metrics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  coordinationMessagesReceived,
+  coordinationMessagesSent,
+  coordinationStateTransitions,
   eventCount,
   promptTokens,
   runCount,
@@ -41,6 +44,21 @@ describe('telemetry/metrics', () => {
     ).not.toThrow();
     expect(() =>
       validationCount.add(1, { valid: false, type: 'system' }),
+    ).not.toThrow();
+  });
+
+  it('coordination counters are defined and do not throw', () => {
+    expect(coordinationMessagesSent).toBeDefined();
+    expect(coordinationMessagesReceived).toBeDefined();
+    expect(coordinationStateTransitions).toBeDefined();
+    expect(() =>
+      coordinationMessagesSent.add(1, { type: 'task', sender: 'outside' }),
+    ).not.toThrow();
+    expect(() =>
+      coordinationMessagesReceived.add(1, { type: 'task' }),
+    ).not.toThrow();
+    expect(() =>
+      coordinationStateTransitions.add(1, { from: 'idle', to: 'in-progress' }),
     ).not.toThrow();
   });
 });

--- a/test/telemetry/spans.test.ts
+++ b/test/telemetry/spans.test.ts
@@ -1,7 +1,10 @@
+import { trace } from '@opentelemetry/api';
 import { describe, expect, it } from 'vitest';
 import {
   BaggageCopyProcessor,
   captureContext,
+  contextFromTraceparent,
+  getTraceContext,
   runInContext,
   setBaggage,
   spanContextFromTraceparent,
@@ -106,6 +109,30 @@ describe('telemetry/spans', () => {
           '00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01',
         ),
       ).toBeUndefined();
+    });
+  });
+
+  describe('contextFromTraceparent', () => {
+    it('builds a parent context that nests a child span under the remote parent', () => {
+      const tp = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+      const parent = contextFromTraceparent(tp);
+      expect(parent).toBeDefined();
+      const sc = parent ? trace.getSpanContext(parent) : undefined;
+      expect(sc?.traceId).toBe('0af7651916cd43dd8448eb211c80319c');
+      expect(sc?.spanId).toBe('b7ad6b7169203331');
+      expect(sc?.isRemote).toBe(true);
+    });
+
+    it('returns undefined for missing or malformed traceparent', () => {
+      expect(contextFromTraceparent(undefined)).toBeUndefined();
+      expect(contextFromTraceparent('garbage')).toBeUndefined();
+    });
+  });
+
+  describe('getTraceContext', () => {
+    it('returns an empty object when there is no active span', () => {
+      // No SDK registered in unit tests → noop propagator → empty carrier.
+      expect(getTraceContext()).toEqual({});
     });
   });
 });

--- a/test/telemetry/spans.test.ts
+++ b/test/telemetry/spans.test.ts
@@ -4,6 +4,7 @@ import {
   captureContext,
   runInContext,
   setBaggage,
+  spanContextFromTraceparent,
   withSpan,
   withSpanSync,
 } from '../../src/telemetry/spans.js';
@@ -35,6 +36,12 @@ describe('telemetry/spans', () => {
     ).toThrow('sync error');
   });
 
+  it('withSpanSync accepts an explicit parentContext', () => {
+    const parent = captureContext();
+    const result = withSpanSync('test.span', () => 'rooted', undefined, parent);
+    expect(result).toBe('rooted');
+  });
+
   it('setBaggage returns a context', () => {
     const ctx = setBaggage({ 'minih.test': 'value' });
     expect(ctx).toBeDefined();
@@ -57,5 +64,48 @@ describe('telemetry/spans', () => {
     expect(typeof processor.onEnd).toBe('function');
     expect(typeof processor.shutdown).toBe('function');
     expect(typeof processor.forceFlush).toBe('function');
+  });
+
+  describe('spanContextFromTraceparent', () => {
+    it('parses a valid sampled traceparent into a remote SpanContext', () => {
+      const sc = spanContextFromTraceparent(
+        '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01',
+      );
+      expect(sc).toEqual({
+        traceId: '0af7651916cd43dd8448eb211c80319c',
+        spanId: 'b7ad6b7169203331',
+        traceFlags: 1,
+        isRemote: true,
+      });
+    });
+
+    it('parses an unsampled traceparent (flags 00)', () => {
+      const sc = spanContextFromTraceparent(
+        '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00',
+      );
+      expect(sc?.traceFlags).toBe(0);
+    });
+
+    it('returns undefined for undefined input', () => {
+      expect(spanContextFromTraceparent(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for malformed input', () => {
+      expect(spanContextFromTraceparent('not-a-traceparent')).toBeUndefined();
+      expect(spanContextFromTraceparent('00-tooshort-x-01')).toBeUndefined();
+    });
+
+    it('returns undefined for all-zero trace or span ids', () => {
+      expect(
+        spanContextFromTraceparent(
+          '00-00000000000000000000000000000000-b7ad6b7169203331-01',
+        ),
+      ).toBeUndefined();
+      expect(
+        spanContextFromTraceparent(
+          '00-0af7651916cd43dd8448eb211c80319c-0000000000000000-01',
+        ),
+      ).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extends the OpenTelemetry instrumentation (landed in #57) to cover the **inter-agent coordination channel** — the file-based inbox/state subsystem, the runner forwarders, and the inside MCP coordination server — which were previously invisible to tracing. Every change is opt-in (`MINIH_TELEMETRY=true`) with zero overhead when disabled.

All work was verified **end-to-end against a live Grafana LGTM stack**: a coordinated `coordination-smoke-test` run now produces a single, fully-connected trace where the MCP tool calls, forwarder deliveries, and Copilot SDK turns are all stitched under one root — and each `minih.mcp.<tool>` span nests under the exact `execute_tool` span that invoked it.

## What's included

**Coordination instrumentation**
- **Inside MCP server telemetry** — the coordination subprocess inits/flushes telemetry and emits one `minih.mcp.<tool>` span per call (`inbox_*`, `state_*`, `wait_for_any`, …).
- **Per-call MCP span nesting (SEP-414)** — the MCP server reads the `traceparent` the Copilot CLI injects into each `tools/call`'s `params._meta` and roots each `minih.mcp.<tool>` span under the invoking `execute_tool` span (falls back to the spawn-time run context when absent; an `mcp.trace_context` attribute records `per-call` / `spawn` / `none`).
- **`traceparent` + `tracestate` on inbox messages** — added to the `InboxMessage` schema/type and threaded through all four message parsers; producers stamp both W3C keys. The forwarder emits a `minih.coordination.message_received` span **linked** to the producer's span (async-messaging span links, not parent/child).
- **Forwarder + state spans** — `minih.coordination.message_received`, `minih.coordination.state_change`, and `state.from`/`state.to` on `state_transition`.
- **Coordination metrics** — `minih.coordination.messages_sent` / `messages_received` / `state_transitions`.
- **Message content on spans** — `message.subject` + `message.body.length` always; full `message.body` only when `MINIH_TELEMETRY_VERBOSE=true` (privacy-safe default, mirrors `prompt.body`).

**Cross-process correctness fixes (found via live LGTM verification)**
- **DD11 `TRACEPARENT` extraction** — env vars are UPPERCASE but the W3C propagator reads lowercase carrier keys, so cross-process stitching silently never worked. Now normalizes the carrier. This is why MCP spans were orphaning into their own traces; it also fixes the documented `minih check`-in-`minih run` stitching. (+ regression test.)
- **SDK span flush race** — on long runs the Copilot CLI's `invoke_agent` root span (ends last) was killed by `client.stop()`'s SIGTERM before its batch flushed, orphaning the whole `github-copilot` subtree. Setting `OTEL_BSP_SCHEDULE_DELAY` for the inherited subprocess makes it flush frequently — deterministic, replacing reliance on a fixed sleep.

**Primitives + docs**
- `withSpanSync(parentContext)`, `spanContextFromTraceparent()`, `contextFromTraceparent()`, `getTraceContext()`, `addSpanAttributes()` telemetry helpers.
- `MINIH_TELEMETRY_FLUSH_MS` knob (bounded settle window).
- `docs/telemetry.md` updated: coordinated-run span tree, coordination metrics, message-content attributes, and cross-run `TRACEPARENT` stitching.

## Verification

- `just fft` → green (lint, format, build, typecheck, tests, audit); the only intermittent failures are the repo's known load-sensitive CLI-subprocess tests, which pass in isolation.
- Live LGTM: coordinated run → one fully-connected trace; `minih.mcp.*` spans nest under their `execute_tool` parent (`mcp.trace_context=per-call`); message content visible on spans in verbose mode; metrics + logs present.

<img width="1249" height="1167" alt="image" src="https://github.com/user-attachments/assets/cbfcef1d-b5f8-422d-a62a-c993b02a4ec1" />

## Notes / remaining follow-ups

- **`tracestate` link consumption** — `tracestate` is now stamped on send and carried on the envelope, but it is not attached to the receive-side link/parent `SpanContext` (nesting only needs trace/span ids; low value, and `@opentelemetry/core`'s `createTraceState` isn't exported at the pinned version). Deferred.
- **`baggage` propagation across the MCP boundary** (also per SEP-414) — out of scope for this PR; minih sets baggage (DD5) but doesn't yet forward it via `_meta.baggage`. Deferred.
